### PR TITLE
Update to use access_token

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -11,7 +11,7 @@ resource "google_container_cluster" "engineering" {
   # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count       = 1
-  
+
   ip_allocation_policy {}
 }
 

--- a/gke.tf
+++ b/gke.tf
@@ -1,5 +1,7 @@
 data "google_compute_zones" "available" {}
 
+data "google_client_config" "default" {}
+
 resource "google_container_cluster" "engineering" {
   name     = var.cluster_name
   location = data.google_compute_zones.available.names.0
@@ -40,8 +42,6 @@ data "template_file" "kubeconfig" {
 
   vars = {
     cluster_name    = google_container_cluster.engineering.name
-    user_name       = google_container_cluster.engineering.master_auth[0].username
-    user_password   = google_container_cluster.engineering.master_auth[0].password
     endpoint        = google_container_cluster.engineering.endpoint
     cluster_ca      = google_container_cluster.engineering.master_auth[0].cluster_ca_certificate
     client_cert     = google_container_cluster.engineering.master_auth[0].client_certificate

--- a/kubeconfig-template.yaml
+++ b/kubeconfig-template.yaml
@@ -7,17 +7,9 @@ contexts:
 - context:
     cluster: ${cluster_name}
     namespace: default
-    user: ${user_name}
   name: hashicorp-learn
 clusters:
 - cluster:
     server: https://${endpoint}
     certificate-authority-data: ${cluster_ca}
   name: ${cluster_name}
-users:
-- name: ${user_name}
-  user:
-    password: ${user_password}
-    username: ${user_name}
-    client-certificate-data: ${client_cert}
-    client-key-data: ${client_cert_key}

--- a/main.tf
+++ b/main.tf
@@ -1,21 +1,19 @@
 terraform {
   backend "remote" {
-    organization = "hashicorp-learn"    
+    organization = "infrastructure-pipelines-workshop"
     workspaces {
-      name = "learn-terraform-pipelines-k8s"
+      name = "john-d-k8s"
     }
   }
-required_providers {
+  required_providers {
     google = {
       source  = "hashicorp/google"
       version = "~> 3.55"
     }
+  }
+
+  required_version = "~> 0.14"
 }
-
-required_version = "~> 0.14"
-}
-
-
 
 provider "google" {
   project = var.google_project

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,11 +12,6 @@ output "access_token" {
   sensitive  = true
 }
 
-output "cluster_ca_certificate" {
-  value     = base64decode(google_container_cluster.engineering.master_auth.0.cluster_ca_certificate)
-  sensitive = true
-}
-
 output "enable_consul_and_vault" {
   value = var.enable_consul_and_vault
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,8 +8,8 @@ output "host" {
 }
 
 output "access_token" {
-  value      = data.google_client_config.default.access_token
-  sensitive  = true
+  value     = data.google_client_config.default.access_token
+  sensitive = true
 }
 
 output "enable_consul_and_vault" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,18 +7,13 @@ output "host" {
   sensitive = true
 }
 
+output "access_token" {
+  value      = data.google_client_config.default.access_token
+  sensitive  = true
+}
+
 output "cluster_ca_certificate" {
   value     = base64decode(google_container_cluster.engineering.master_auth.0.cluster_ca_certificate)
-  sensitive = true
-}
-
-output "username" {
-  value     = google_container_cluster.engineering.master_auth.0.username
-  sensitive = true
-}
-
-output "password" {
-  value     = google_container_cluster.engineering.master_auth.0.password
   sensitive = true
 }
 


### PR DESCRIPTION
The previous config used username/password, which is no longer an option now that [master auth](https://github.com/hashicorp/learn-terraform-pipelines-k8s/pull/6) is no longer supported. This PR switches to access_token for the workshop.