### PR TITLE
latest is not working, use default instead

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -26,7 +26,7 @@ resource "google_container_node_pool" "engineering_preemptible_nodes" {
   cluster  = google_container_cluster.engineering.name
   location = data.google_compute_zones.available.names.0
 
-  version    = data.google_container_engine_versions.gke_version.release_channel_latest_version["STABLE"]
+  version    = data.google_container_engine_versions.gke_version.release_channel_default_version["STABLE"]
   node_count = var.node_count
 
   node_config {


### PR DESCRIPTION
fixes this error...

│ Error: Invalid index
│ 
│   on gke.tf line 29, in resource "google_container_node_pool" "engineering_preemptible_nodes":
│   29:   version    = data.google_container_engine_versions.gke_version.release_channel_latest_version["STABLE"]
│     ├────────────────
│     │ data.google_container_engine_versions.gke_version.release_channel_latest_version is empty map of string
│ 
│ The given key does not identify an element in this collection value.